### PR TITLE
Make dependencies debian 11 compatible

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-Pillow >= 9.2.0
-pygobject >=3.42.2
+Pillow >= 9.0.1
+pygobject >=3.42.1
 pyzmq >= 24.0.0
-setproctitle >= 1.3.2
+setproctitle >= 1.2.2
 qrcode >= 7.3.1


### PR DESCRIPTION
I lowered the minimum version of dependencies.  
For some reason pycairo breaks on debian with newer version.  
I tested it and everything seems to still work just fine.

This fixes the issue i mentioned in Issue #2 