### PR TITLE
More features

### DIFF
--- a/src/a2ln/a2ln.py
+++ b/src/a2ln/a2ln.py
@@ -231,9 +231,7 @@ class NotificationServer(threading.Thread):
                                      daemon=True).start()
 
                     if self.command is not None:
-                        subprocess.Popen(
-                            replace(self.command),
-                            shell=True)
+                        subprocess.Popen(replace(self.command), shell=True)
 
     def update_client_public_keys(self) -> None:
         if self.authenticator is not None and self.authenticator.is_alive():

--- a/src/a2ln/a2ln.py
+++ b/src/a2ln/a2ln.py
@@ -116,7 +116,7 @@ def parse_args() -> Namespace:
                                  help="The port to listen for pairing requests (by default random)")
     argument_parser.add_argument("--title-format", type=str, default="{title}",
                                  help="The format of the title. Available placeholders: {app}, {title}, {body} (by default {title})")
-    argument_parser.add_argument("--body-format", type=str, default="{title}",
+    argument_parser.add_argument("--body-format", type=str, default="{body}",
                                  help="The format of the body. Available placeholders: {app}, {title}, {body} (by default {body})")
     argument_parser.add_argument("--command", type=str,
                                  help="A shell command to run whenever a notification arrives. Available placeholders: {app}, {title}, {body} (by default none)")

--- a/src/a2ln/a2ln.py
+++ b/src/a2ln/a2ln.py
@@ -222,17 +222,17 @@ class NotificationServer(threading.Thread):
                     else:
                         picture_file = None
 
-                    app = request[0].decode("utf-8")
-                    title = request[1].decode("utf-8")
-                    body = request[2].decode("utf-8")
+                    def replace(text: str) -> str:
+                        return text.replace("{app}", request[0].decode("utf-8")).replace("{title}", request[1].decode(
+                            "utf-8")).replace("{body}", request[2].decode("utf-8"))
 
-                    threading.Thread(target=send_notification, args=(self.title_format.replace("{app}", app).replace(
-                        "{title}", title).replace("{body}", body), self.body_format.replace("{app}", app).replace(
-                        "{title}", title).replace("{body}", body), picture_file), daemon=True).start()
+                    threading.Thread(target=send_notification,
+                                     args=(replace(self.title_format), replace(self.body_format), picture_file),
+                                     daemon=True).start()
 
                     if self.command is not None:
                         subprocess.Popen(
-                            self.command.replace("{app}", app).replace("{title}", title).replace("{body}", body),
+                            replace(self.command),
                             shell=True)
 
     def update_client_public_keys(self) -> None:

--- a/src/a2ln/a2ln.py
+++ b/src/a2ln/a2ln.py
@@ -75,12 +75,11 @@ def main():
 
         if not args.no_notification_server:
             notification_server = NotificationServer(client_public_keys_directory, own_public_key, own_secret_key,
-                                                     args.notification_ip, args.notification_port, args.title_format, args.body_format,
+                                                     args.notification_ip, args.notification_port, args.title_format,
+                                                     args.body_format,
                                                      args.command)
 
             notification_server.start()
-
-            time.sleep(1)
 
         if not args.no_pairing_server:
             if notification_server is not None:


### PR DESCRIPTION
This PR adds
- a `--body-format` option
- and a way to not start the pairing or notification server (so there are no unnecessary ports open).