### PR TITLE
Fix a few type annotations for mypy

### DIFF
--- a/src/a2ln/a2ln.py
+++ b/src/a2ln/a2ln.py
@@ -23,6 +23,7 @@ import threading
 import time
 import traceback
 from argparse import Namespace
+from typing import Optional
 from pathlib import Path
 
 import gi
@@ -130,7 +131,7 @@ def get_ip() -> str:
         return client.getsockname()[0]
 
 
-def send_notification(title: str, text: str, picture_file: tempfile = None) -> None:
+def send_notification(title: str, text: str, picture_file: Optional[tempfile._TemporaryFileWrapper] = None) -> None:
     if picture_file is None:
         Notify.Notification.new(title, text, "dialog-information").show()
     else:
@@ -141,7 +142,7 @@ def send_notification(title: str, text: str, picture_file: tempfile = None) -> N
     print(f"{GREEN_PREFIX}Sent notification (Title: {BOLD}{title}{RESET}, Text: {BOLD}{text}{RESET})")
 
 
-def inform(name: str, ip: str = None, port: int = None, error: zmq.error.ZMQError = None) -> None:
+def inform(name: str, ip: Optional[str] = None, port: Optional[int] = None, error: zmq.error.ZMQError = None) -> None:
     if error is None:
         print(
             f"{GREEN_PREFIX}{name.capitalize()} server running on IP {BOLD}{ip}{RESET} and port {BOLD}{port}{RESET}.")
@@ -173,7 +174,7 @@ class NotificationServer(threading.Thread):
         self.title_format = title_format
         self.body_format = body_format
         self.command = command
-        self.authenticator = None
+        self.authenticator: Optional[zmq.auth.thread.ThreadAuthenticator] = None
 
     def run(self) -> None:
         super(NotificationServer, self).run()

--- a/src/a2ln/a2ln.py
+++ b/src/a2ln/a2ln.py
@@ -23,8 +23,8 @@ import threading
 import time
 import traceback
 from argparse import Namespace
-from typing import Optional
 from pathlib import Path
+from typing import Optional
 
 import gi
 import qrcode
@@ -142,7 +142,8 @@ def send_notification(title: str, text: str, picture_file: Optional[tempfile._Te
     print(f"{GREEN_PREFIX}Sent notification (Title: {BOLD}{title}{RESET}, Text: {BOLD}{text}{RESET})")
 
 
-def inform(name: str, ip: Optional[str] = None, port: Optional[int] = None, error: zmq.error.ZMQError = None) -> None:
+def inform(name: str, ip: Optional[str] = None, port: Optional[int] = None,
+           error: Optional[zmq.error.ZMQError] = None) -> None:
     if error is None:
         print(
             f"{GREEN_PREFIX}{name.capitalize()} server running on IP {BOLD}{ip}{RESET} and port {BOLD}{port}{RESET}.")
@@ -163,7 +164,7 @@ def inform(name: str, ip: Optional[str] = None, port: Optional[int] = None, erro
 
 class NotificationServer(threading.Thread):
     def __init__(self, client_public_keys_directory: Path, own_public_key: bytes, own_secret_key: bytes, ip: str,
-                 port: int, title_format: str, body_format: str, command: str):
+                 port: int, title_format: str, body_format: str, command: Optional[str]):
         super(NotificationServer, self).__init__(daemon=True)
 
         self.client_public_keys_directory = client_public_keys_directory
@@ -174,6 +175,7 @@ class NotificationServer(threading.Thread):
         self.title_format = title_format
         self.body_format = body_format
         self.command = command
+
         self.authenticator: Optional[zmq.auth.thread.ThreadAuthenticator] = None
 
     def run(self) -> None:
@@ -240,8 +242,8 @@ class NotificationServer(threading.Thread):
 
 
 class PairingServer(threading.Thread):
-    def __init__(self, client_public_keys_directory: Path, own_public_key: bytes, ip: str, port: int,
-                 notification_server: NotificationServer):
+    def __init__(self, client_public_keys_directory: Path, own_public_key: bytes, ip: str, port: Optional[int],
+                 notification_server: Optional[NotificationServer]):
         super(PairingServer, self).__init__(daemon=True)
 
         self.client_public_keys_directory = client_public_keys_directory

--- a/src/a2ln/a2ln.py
+++ b/src/a2ln/a2ln.py
@@ -76,9 +76,8 @@ def main():
 
         if not args.no_notification_server:
             notification_server = NotificationServer(client_public_keys_directory, own_public_key, own_secret_key,
-                                                     args.notification_ip, args.notification_port, args.title_format,
-                                                     args.body_format,
-                                                     args.command)
+                                                     args.notification_ip, args.notification_port, args.command, args.title_format,
+                                                     args.body_format)
 
             notification_server.start()
 
@@ -164,7 +163,7 @@ def inform(name: str, ip: Optional[str] = None, port: Optional[int] = None,
 
 class NotificationServer(threading.Thread):
     def __init__(self, client_public_keys_directory: Path, own_public_key: bytes, own_secret_key: bytes, ip: str,
-                 port: int, title_format: str, body_format: str, command: Optional[str]):
+                 port: int, command: Optional[str], title_format: Optional[str], body_format: Optional[str]):
         super(NotificationServer, self).__init__(daemon=True)
 
         self.client_public_keys_directory = client_public_keys_directory
@@ -172,9 +171,9 @@ class NotificationServer(threading.Thread):
         self.own_secret_key = own_secret_key
         self.ip = ip
         self.port = port
-        self.title_format = title_format
-        self.body_format = body_format
         self.command = command
+        self.title_format = "{title}" if title_format is None else title_format
+        self.body_format = "{body}" if body_format is None else body_format
 
         self.authenticator: Optional[zmq.auth.thread.ThreadAuthenticator] = None
 

--- a/src/a2ln/a2ln.py
+++ b/src/a2ln/a2ln.py
@@ -76,7 +76,8 @@ def main():
 
         if not args.no_notification_server:
             notification_server = NotificationServer(client_public_keys_directory, own_public_key, own_secret_key,
-                                                     args.notification_ip, args.notification_port, args.command, args.title_format,
+                                                     args.notification_ip, args.notification_port, args.command,
+                                                     args.title_format,
                                                      args.body_format)
 
             notification_server.start()


### PR DESCRIPTION
Fixed a few issues with type annotations to make it (more) [mypy](https://www.mypy-lang.org/) compatible.

- `Optional[TYPE]` is necessary if it can be `None`
- the `auth.zmq` is necessary to tell mypy it is not just `None` and prevent it from marking other things as wrong
- i got `tempfile._TemporaryFileWrapper`  by running `import tempfile; type(tempfile.NamedTemporaryFile(suffix="png"))` in a interactive session

it is still not 100% mypy compatible since some of the used libraries are not annotated and therefore not everything can be checked.