### PR TITLE
Fix LAN IP detection under VPN policy routing, exit pairing loop on demand

### DIFF
--- a/src/a2ln/a2ln.py
+++ b/src/a2ln/a2ln.py
@@ -342,5 +342,5 @@ class PairingServer(threading.Thread):
 
                 print("Pairing finished.")
 
-                if input("Pair another device? (yes/No): ").lower() != "yes":
+                if input("Pair another device? (yes/No): ").strip().lower() != "yes":
                     break

--- a/src/a2ln/a2ln.py
+++ b/src/a2ln/a2ln.py
@@ -17,6 +17,7 @@
 import argparse
 import io
 import os
+import re
 import signal
 import socket
 import subprocess
@@ -137,6 +138,19 @@ def parse_args() -> Namespace:
 
 
 def get_ip() -> str:
+    try:
+        result = subprocess.run(
+            ["ip", "route", "show", "table", "main", "default"],
+            capture_output=True, text=True, check=True,
+        )
+
+        match = re.search(r"\bsrc (\d+\.\d+\.\d+\.\d+)", result.stdout)
+
+        if match:
+            return match.group(1)
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        pass
+
     with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as client:
         client.connect(("8.8.8.8", 80))
 
@@ -327,3 +341,6 @@ class PairingServer(threading.Thread):
                 server.send(self.own_public_key)
 
                 print("Pairing finished.")
+
+                if input("Pair another device? (yes/No): ").lower() != "yes":
+                    break

--- a/src/a2ln/a2ln.py
+++ b/src/a2ln/a2ln.py
@@ -325,7 +325,7 @@ class PairingServer(threading.Thread):
                 print(f"Public Key: {BOLD}{client_public_key}{RESET}")
                 print()
 
-                if input("Accept? (Yes/No): ").lower() != "yes":
+                if input("Accept? (Yes/No): ").strip().lower() != "yes":
                     print("Pairing cancelled.")
 
                     server.send(b"")
@@ -342,5 +342,5 @@ class PairingServer(threading.Thread):
 
                 print("Pairing finished.")
 
-                if input("Pair another device? (yes/No): ").strip().lower() != "yes":
+                if input("Pair another device? (Yes/No): ").strip().lower() != "yes":
                     break


### PR DESCRIPTION
## Summary
- `get_ip()` displayed the wrong IP in the pairing QR code/text when a VPN adds per-uid or fwmark-based policy routes (e.g. ProtonVPN). The existing UDP-socket trick to find the local source address followed those policy routes straight into the VPN tunnel instead of the real LAN. Now it first queries the main routing table directly (`ip route show table main default`), which reflects the actual LAN default route regardless of VPN policy rules, falling back to the original socket trick if that's unavailable.
- The pairing server looped forever after a successful pairing with no way to stop except Ctrl+C. It now asks "Pair another device? (yes/No)" after each pairing, so a single pairing session ends cleanly by default while still supporting pairing multiple devices in one run.

## Test plan
- [x] `python3 -m py_compile`/`compile()` on the patched file succeeds
- [x] Reproduced the wrong-IP bug locally with ProtonVPN's split-tunneling/policy routing active; confirmed `a2ln pair` now shows the real LAN IP instead of the VPN tunnel IP
- [x] Ran `a2ln pair`, paired a device, confirmed it now exits the loop by default after one pairing, and still loops when answering "yes"